### PR TITLE
Feature: Optional compression

### DIFF
--- a/src/main/java/de/dddns/kirbylink/warp4j/config/Warp4JCommand.java
+++ b/src/main/java/de/dddns/kirbylink/warp4j/config/Warp4JCommand.java
@@ -46,6 +46,9 @@ public class Warp4JCommand implements Callable<Integer> {
 
   @Option(names = {"--optimize"}, description = "Use optimized JRE instead of JDK")
   private boolean isOptimize;
+  
+  @Option(names = {"--no-compress"}, description = "Skip compression of the created binary file.")
+  private boolean isNoCompress;
 
   @Option(names = {"--add-modules"}, description = " A list of additional java modules that should be added to the optimized JDK. Separate each module with commas and no spaces")
   private String additionalModules = "";
@@ -117,6 +120,7 @@ public class Warp4JCommand implements Callable<Integer> {
           .macosX64(isMacosX64)
           .macosAarch64(isMacosAarch64)
           .optimize(isOptimize)
+          .compress(!isNoCompress)
           .outputDirectoryPath(outputDirectoryPath)
           .prefix(prefix)
           .pull(isPull)
@@ -189,6 +193,7 @@ public class Warp4JCommand implements Callable<Integer> {
     private final Path outputDirectoryPath;
     private final String prefix;
     private final boolean optimize;
+    private final boolean compress;
     private final String additionalModules;
     private final boolean linux;
     private final boolean linuxX64;

--- a/src/main/java/de/dddns/kirbylink/warp4j/service/Warp4JService.java
+++ b/src/main/java/de/dddns/kirbylink/warp4j/service/Warp4JService.java
@@ -128,13 +128,15 @@ public class Warp4JService {
         .filter(Objects::nonNull)
         .toList();
 
-    log.info("Compress binaries...");
-    jdkProcessingStates = jdkProcessingStates.stream()
-        .filter(JdkProcessingState::isTarget)
-        .map(this::compressBundle)
-        .filter(Objects::nonNull)
-        .toList();
-
+    if (warp4jCommandConfiguration.isCompress()) {
+      log.info("Compress binaries...");
+      jdkProcessingStates = jdkProcessingStates.stream()
+          .filter(JdkProcessingState::isTarget)
+          .map(this::compressBundle)
+          .filter(Objects::nonNull)
+          .toList();
+    }
+    
     var successfulWarped = String.join(", ", jdkProcessingStates.stream().filter(JdkProcessingState::success).map(jdkProcessingState -> jdkProcessingState.bundledBinary().toString()).toList());
     log.debug("Warp successfull for: {}", successfulWarped);
 

--- a/src/test/java/de/dddns/kirbylink/warp4j/service/Warp4JServiceTest.java
+++ b/src/test/java/de/dddns/kirbylink/warp4j/service/Warp4JServiceTest.java
@@ -532,6 +532,7 @@ class Warp4JServiceTest {
       var architecture = Architecture.X64;
       var target = new Target(platform, architecture);
       mockUntilJdkPreparation("x64", "Windows 10", target);
+      when(mockedWarp4jCommandConfiguration.isCompress()).thenReturn(true);
       var jdkProcessingStateTarget = JdkProcessingState.builder().target(target).isTarget(true).extractedJdkPath(mockedExtractedPath).build();
       mockCollectionOfCachedFiles(jdkProcessingStateTarget);
       mockCopyJdkToBundleDirectory(target);
@@ -546,6 +547,30 @@ class Warp4JServiceTest {
       // Then
       assertThat(actualReturnValue).isZero();
       verify(mockedFileService).compressBundle(target, mockedOutputDirectoryPath);
+    }
+    
+    @Test
+    void testCreateExecutableJarFile_WhenNoCompressOptionIsSelected_ThenWarpedBundleWillNotBeCompressed() throws IOException, NoPermissionException, InterruptedException {
+      // GIven
+      var platform = Platform.WINDOWS;
+      var architecture = Architecture.X64;
+      var target = new Target(platform, architecture);
+      mockUntilJdkPreparation("x64", "Windows 10", target);
+      when(mockedWarp4jCommandConfiguration.isCompress()).thenReturn(false);
+      var jdkProcessingStateTarget = JdkProcessingState.builder().target(target).isTarget(true).extractedJdkPath(mockedExtractedPath).build();
+      mockCollectionOfCachedFiles(jdkProcessingStateTarget);
+      mockCopyJdkToBundleDirectory(target);
+      mockCopyJarFileAndCreateLauncherScriptToBundleDirectory(target);
+      mockWarpBundle(target);
+      
+      when(mockedFileService.compressBundle(target, mockedOutputDirectoryPath)).thenReturn(true);
+      
+      // When
+      var actualReturnValue = warp4JService.createExecutableJarFile(mockedWarp4jCommandConfiguration);
+      
+      // Then
+      assertThat(actualReturnValue).isZero();
+      verify(mockedFileService, never()).compressBundle(target, mockedOutputDirectoryPath);
     }
   }
 


### PR DESCRIPTION
## Description

Adds a parameter to disable compression.

To maintain backward compatibility, `no-compress` is introduced as a new parameter instead of `--compress`.
In a major update, this may be changed to `--compress`.

Fixes # (issue)
#2 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

<!--
**Unit Tests:**
- Add a unit test for the `doSomething` method to ensure invalid inputs are handled correctly.
  - Test A: Pass an invalid number (e.g., "abc") and verify that an error message is returned.
  - Test B: Pass a negative number and verify that the appropriate error message is returned.

**Integration Tests:**
- Perform an integration test for the new PDF export feature.
  - Test C: Verify that the PDF file is generated correctly and contains the calculated values and the date.

**Manual Tests:**
- Manually test the application by entering various valid and invalid numbers and verifying the results.
- Manually export the results as a PDF and check the contents of the generated PDF files.
-->

**Unit Tests:**
- Add a unit test for the `createExecutableJarFile` method in Warp4JService to ensure that compression is skipped when `--no-compress` parameter is passed to the application.
  - Test `testCreateExecutableJarFile_WhenNoCompressOptionIsSelected_ThenWarpedBundleWillNotBeCompressed`: Warp4jCommandConfiguration.isCompress() returns false and it is checked that the method `FileService#compressBundle(Target target, Path bundledBinaryPath)` is not executed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

